### PR TITLE
Add Ubuntu support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.log
 *.lock
 Makefile
+tmp/

--- a/ext/sctp/extconf.rb
+++ b/ext/sctp/extconf.rb
@@ -2,4 +2,5 @@ require 'mkmf'
 
 have_header('netinet/sctp.h')
 have_library('sctp')
+have_func('sctp_sendv', 'netinet/sctp.h')
 create_makefile('sctp/socket')

--- a/ext/sctp/extconf.rb
+++ b/ext/sctp/extconf.rb
@@ -3,4 +3,5 @@ require 'mkmf'
 have_header('netinet/sctp.h')
 have_library('sctp')
 have_func('sctp_sendv', 'netinet/sctp.h')
+have_struct_member('struct sctp_event_subscribe', 'sctp_send_failure_event', 'netinet/sctp.h')
 create_makefile('sctp/socket')

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -791,13 +791,7 @@ static VALUE rsctp_recvmsg(int argc, VALUE* argv, VALUE self){
           UINT2NUM(snp->sn_send_failed.ssf_type),
           UINT2NUM(snp->sn_send_failed.ssf_length),
           UINT2NUM(snp->sn_send_failed.ssf_error),
-          rb_struct_new(v_sndinfo_struct,
-            UINT2NUM(snp->sn_send_failed.ssf_info.sinfo_sid),
-            UINT2NUM(snp->sn_send_failed.ssf_info.sinfo_flags),
-            UINT2NUM(snp->sn_send_failed.ssf_info.sinfo_ppid),
-            UINT2NUM(snp->sn_send_failed.ssf_info.sinfo_context),
-            UINT2NUM(snp->sn_send_failed.ssf_info.sinfo_assoc_id)
-          ),
+          Qnil,
           UINT2NUM(snp->sn_send_failed.ssf_assoc_id),
           rb_ary_new4(snp->sn_send_failed.ssf_length, v_temp)
         );
@@ -963,9 +957,12 @@ static VALUE rsctp_subscribe(VALUE self, VALUE v_options){
   if(RTEST(rb_hash_aref2(v_options, "address")))
     events.sctp_address_event = 1;
 
-  // Use the new version
   if(RTEST(rb_hash_aref2(v_options, "send_failure")))
+#ifdef HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE_SCTP_SEND_FAILURE_EVENT
+    events.sctp_send_failure_event = 1;
+#else
     events.sctp_send_failure_event_event = 1;
+#endif
 
   if(RTEST(rb_hash_aref2(v_options, "peer_error")))
     events.sctp_peer_error_event = 1;

--- a/tmp/x86_64-linux/socket/3.0.2/.rake-compiler-siteconf.rb
+++ b/tmp/x86_64-linux/socket/3.0.2/.rake-compiler-siteconf.rb
@@ -1,0 +1,7 @@
+require 'rbconfig'
+require 'mkmf'
+dest_path = mkintpath("/home/dberger/Dev/sctp-socket/lib/sctp")
+RbConfig::MAKEFILE_CONFIG['sitearchdir'] = dest_path
+RbConfig::CONFIG['sitearchdir'] = dest_path
+RbConfig::MAKEFILE_CONFIG['sitelibdir'] = dest_path
+RbConfig::CONFIG['sitelibdir'] = dest_path

--- a/tmp/x86_64-linux/socket/3.0.2/.rake-compiler-siteconf.rb
+++ b/tmp/x86_64-linux/socket/3.0.2/.rake-compiler-siteconf.rb
@@ -1,7 +1,0 @@
-require 'rbconfig'
-require 'mkmf'
-dest_path = mkintpath("/home/dberger/Dev/sctp-socket/lib/sctp")
-RbConfig::MAKEFILE_CONFIG['sitearchdir'] = dest_path
-RbConfig::CONFIG['sitearchdir'] = dest_path
-RbConfig::MAKEFILE_CONFIG['sitelibdir'] = dest_path
-RbConfig::CONFIG['sitelibdir'] = dest_path


### PR DESCRIPTION
On Ubuntu 20 it seems that sctp_sendv and SCTP_SEND_FAILED_EVENT are not supported, so this PR skips and/or updates certain bits to workaround that.