### PR TITLE
Support BSD

### DIFF
--- a/ext/sctp/extconf.rb
+++ b/ext/sctp/extconf.rb
@@ -24,8 +24,19 @@ unless have_header('netinet/sctp.h')
   exit
 end
 
+header = 'netinet/sctp.h'
+
 have_library('sctp')
-have_func('sctp_sendv', 'netinet/sctp.h')
-have_func('sctp_recvv', 'netinet/sctp.h')
-have_struct_member('struct sctp_event_subscribe', 'sctp_send_failure_event', 'netinet/sctp.h')
+
+have_func('sctp_sendv', header)
+have_func('sctp_recvv', header)
+
+have_struct_member('struct sctp_event_subscribe', 'sctp_send_failure_event', header)
+have_struct_member('struct sctp_event_subscribe', 'sctp_stream_reset_event', header)
+have_struct_member('struct sctp_event_subscribe', 'sctp_assoc_reset_event', header)
+have_struct_member('struct sctp_event_subscribe', 'sctp_stream_change_event', header)
+have_struct_member('struct sctp_event_subscribe', 'sctp_send_failure_event_event', header)
+
+have_const('SCTP_EMPTY', header)
+
 create_makefile('sctp/socket')

--- a/ext/sctp/extconf.rb
+++ b/ext/sctp/extconf.rb
@@ -39,6 +39,8 @@ have_struct_member('struct sctp_event_subscribe', 'sctp_send_failure_event_event
 
 have_struct_member('struct sctp_send_failed_event', 'ssfe_length', header)
 
+have_struct_member('union sctp_notification', 'sn_auth_event', header)
+
 have_const('SCTP_EMPTY', header)
 
 create_makefile('sctp/socket')

--- a/ext/sctp/extconf.rb
+++ b/ext/sctp/extconf.rb
@@ -37,6 +37,8 @@ have_struct_member('struct sctp_event_subscribe', 'sctp_assoc_reset_event', head
 have_struct_member('struct sctp_event_subscribe', 'sctp_stream_change_event', header)
 have_struct_member('struct sctp_event_subscribe', 'sctp_send_failure_event_event', header)
 
+have_struct_member('struct sctp_send_failed_event', 'ssfe_length', header)
+
 have_const('SCTP_EMPTY', header)
 
 create_makefile('sctp/socket')

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -163,6 +163,28 @@ VALUE get_notification_info(char* buffer){
       break;
 #ifdef SCTP_SEND_FAILED_EVENT
     case SCTP_SEND_FAILED_EVENT:
+#ifdef HAVE_STRUCT_SCTP_SEND_FAILED_EVENT_SSFE_LENGTH
+      v_temp = ALLOCA_N(VALUE, snp->sn_send_failed_event.ssfe_length);
+
+      for(i = 0; i < snp->sn_send_failed_event.ssfe_length; i++){
+        v_temp[i] = UINT2NUM(snp->sn_send_failed_event.ssfe_data[i]);
+      }
+
+      v_notification = rb_struct_new(v_send_failed_event_struct,
+        UINT2NUM(snp->sn_send_failed_event.ssfe_type),
+        UINT2NUM(snp->sn_send_failed_event.ssfe_length),
+        UINT2NUM(snp->sn_send_failed_event.ssfe_error),
+        rb_struct_new(v_sndinfo_struct,
+          UINT2NUM(snp->sn_send_failed_event.ssfe_info.snd_sid),
+          UINT2NUM(snp->sn_send_failed_event.ssfe_info.snd_flags),
+          UINT2NUM(snp->sn_send_failed_event.ssfe_info.snd_ppid),
+          UINT2NUM(snp->sn_send_failed_event.ssfe_info.snd_context),
+          UINT2NUM(snp->sn_send_failed_event.ssfe_info.snd_assoc_id)
+        ),
+        UINT2NUM(snp->sn_send_failed_event.ssfe_assoc_id),
+        rb_ary_new4(snp->sn_send_failed_event.ssfe_length, v_temp)
+      );
+#else
       v_temp = ALLOCA_N(VALUE, snp->sn_send_failed_event.ssf_length);
 
       for(i = 0; i < snp->sn_send_failed_event.ssf_length; i++){
@@ -183,6 +205,7 @@ VALUE get_notification_info(char* buffer){
         UINT2NUM(snp->sn_send_failed_event.ssf_assoc_id),
         rb_ary_new4(snp->sn_send_failed_event.ssf_length, v_temp)
       );
+#endif
       break;
 #else
     case SCTP_SEND_FAILED:

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -252,11 +252,19 @@ VALUE get_notification_info(char* buffer){
       break;
     case SCTP_AUTHENTICATION_EVENT:
       v_notification = rb_struct_new(v_auth_event_struct,
+#ifdef HAVE_UNION_SCTP_NOTIFICATION_SN_AUTH_EVENT
+        UINT2NUM(snp->sn_auth_event.auth_type),
+        UINT2NUM(snp->sn_auth_event.auth_length),
+        UINT2NUM(snp->sn_auth_event.auth_keynumber),
+        UINT2NUM(snp->sn_auth_event.auth_indication),
+        UINT2NUM(snp->sn_auth_event.auth_assoc_id)
+#else
         UINT2NUM(snp->sn_authkey_event.auth_type),
         UINT2NUM(snp->sn_authkey_event.auth_length),
         UINT2NUM(snp->sn_authkey_event.auth_keynumber),
         UINT2NUM(snp->sn_authkey_event.auth_indication),
         UINT2NUM(snp->sn_authkey_event.auth_assoc_id)
+#endif
       );
       break;
     case SCTP_SENDER_DRY_EVENT:

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -380,7 +380,7 @@ static VALUE rsctp_bindx(int argc, VALUE* argv, VALUE self){
   if(NIL_P(v_addresses))
     num_ip = 1;
   else
-    num_ip = RARRAY_LEN(v_addresses);
+    num_ip = (int)RARRAY_LEN(v_addresses);
 
   domain = NUM2INT(rb_iv_get(self, "@domain"));
   fileno = NUM2INT(rb_iv_get(self, "@fileno"));
@@ -458,7 +458,7 @@ static VALUE rsctp_connectx(int argc, VALUE* argv, VALUE self){
 
   v_domain = rb_iv_get(self, "@domain");
 
-  num_ip = RARRAY_LEN(v_addresses);
+  num_ip = (int)RARRAY_LEN(v_addresses);
   bzero(&addrs, sizeof(addrs));
 
   for(i = 0; i < num_ip; i++){
@@ -663,7 +663,7 @@ static VALUE rsctp_sendv(VALUE self, VALUE v_options){
 
   if(!NIL_P(v_addresses)){
     Check_Type(v_addresses, T_ARRAY);
-    num_ip = RARRAY_LEN(v_addresses);
+    num_ip = (int)RARRAY_LEN(v_addresses);
     addrs = (struct sockaddr_in*)alloca(num_ip * sizeof(*addrs));
   }
   else{
@@ -672,7 +672,7 @@ static VALUE rsctp_sendv(VALUE self, VALUE v_options){
   }
 
   fileno = NUM2INT(rb_iv_get(self, "@fileno"));
-  size = RARRAY_LEN(v_message);
+  size = (int)RARRAY_LEN(v_message);
 
   if(!size)
     rb_raise(rb_eArgError, "Must contain at least one message");

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -1566,10 +1566,18 @@ static VALUE rsctp_get_subscriptions(VALUE self){
     (events.sctp_adaptation_layer_event ? Qtrue : Qfalse),
     (events.sctp_authentication_event ? Qtrue : Qfalse),
     (events.sctp_sender_dry_event ? Qtrue : Qfalse),
+#ifdef HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE_SCTP_STREAM_RESET_EVENT
     (events.sctp_stream_reset_event ? Qtrue : Qfalse),
+#endif
+#ifdef HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE_SCTP_ASSOC_RESET_EVENT
     (events.sctp_assoc_reset_event ? Qtrue : Qfalse),
+#endif
+#ifdef HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE_SCTP_STREAM_CHANGE_EVENT
     (events.sctp_stream_change_event ? Qtrue : Qfalse),
+#endif
+#ifdef HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE_SCTP_SEND_FAILURE_EVENT_EVENT
     (events.sctp_send_failure_event_event ? Qtrue : Qfalse)
+#endif
   );
 }
 
@@ -2265,7 +2273,9 @@ void Init_socket(void){
 
   // ASSOCIATION STATES //
 
+#ifdef HAVE_SCTP_EMPTY
   rb_define_const(cSocket, "SCTP_EMPTY", INT2NUM(SCTP_EMPTY));
+#endif
   rb_define_const(cSocket, "SCTP_CLOSED", INT2NUM(SCTP_CLOSED));
   rb_define_const(cSocket, "SCTP_COOKIE_WAIT", INT2NUM(SCTP_COOKIE_WAIT));
   rb_define_const(cSocket, "SCTP_COOKIE_ECHOED", INT2NUM(SCTP_COOKIE_ECHOED));

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -1922,7 +1922,8 @@ static VALUE rsctp_enable_auth_support(int argc, VALUE* argv, VALUE self){
  *  otherwise this will set a key on the endpoint.
 */
 static VALUE rsctp_set_shared_key(int argc, VALUE* argv, VALUE self){
-  int fileno, len;
+  int fileno;
+  size_t len;
   char* key;
   uint keynum;
   socklen_t size;
@@ -1937,7 +1938,7 @@ static VALUE rsctp_set_shared_key(int argc, VALUE* argv, VALUE self){
   len = strlen(key);
   unsigned char byte_array[len+1];
 
-  for(int i = 0; i < len; i++)
+  for(size_t i = 0; i < len; i++)
     byte_array[i] = key[i];
 
   byte_array[len] = '\0';

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -1600,18 +1600,18 @@ static VALUE rsctp_get_subscriptions(VALUE self){
     (events.sctp_partial_delivery_event ? Qtrue : Qfalse),
     (events.sctp_adaptation_layer_event ? Qtrue : Qfalse),
     (events.sctp_authentication_event ? Qtrue : Qfalse),
-    (events.sctp_sender_dry_event ? Qtrue : Qfalse),
+    (events.sctp_sender_dry_event ? Qtrue : Qfalse)
 #ifdef HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE_SCTP_STREAM_RESET_EVENT
-    (events.sctp_stream_reset_event ? Qtrue : Qfalse),
+    ,(events.sctp_stream_reset_event ? Qtrue : Qfalse)
 #endif
 #ifdef HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE_SCTP_ASSOC_RESET_EVENT
-    (events.sctp_assoc_reset_event ? Qtrue : Qfalse),
+    ,(events.sctp_assoc_reset_event ? Qtrue : Qfalse)
 #endif
 #ifdef HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE_SCTP_STREAM_CHANGE_EVENT
-    (events.sctp_stream_change_event ? Qtrue : Qfalse),
+    ,(events.sctp_stream_change_event ? Qtrue : Qfalse)
 #endif
 #ifdef HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE_SCTP_SEND_FAILURE_EVENT_EVENT
-    (events.sctp_send_failure_event_event ? Qtrue : Qfalse)
+    ,(events.sctp_send_failure_event_event ? Qtrue : Qfalse)
 #endif
   );
 }


### PR DESCRIPTION
We're assuming sctplib for BSD flavors. There were a few struct members here and there unsupported, and I did some typecasting to make both Linux and BSD happy.