### PR TITLE
BSD fixes

### DIFF
--- a/ext/sctp/extconf.rb
+++ b/ext/sctp/extconf.rb
@@ -28,6 +28,8 @@ header = 'netinet/sctp.h'
 
 have_library('sctp')
 
+have_header('sys/param.h')
+
 have_func('sctp_sendv', header)
 have_func('sctp_recvv', header)
 

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -4,6 +4,10 @@
 #include <arpa/inet.h>
 #include <netinet/sctp.h>
 
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+
 VALUE mSCTP;
 VALUE cSocket;
 VALUE v_sndrcv_struct;
@@ -391,12 +395,18 @@ static VALUE rsctp_bindx(int argc, VALUE* argv, VALUE self){
       addrs[i].sin_family = domain;
       addrs[i].sin_port = htons(port);
       addrs[i].sin_addr.s_addr = inet_addr(StringValueCStr(v_address));
+#ifdef BSD
+      addrs[i].sin_len = sizeof(struct sockaddr_in);
+#endif
     }
   }
   else{
     addrs[0].sin_family = domain;
     addrs[0].sin_port = htons(port);
     addrs[0].sin_addr.s_addr = htonl(INADDR_ANY);
+#ifdef BSD
+    addrs[0].sin_len = sizeof(struct sockaddr_in);
+#endif
   }
 
   if(sctp_bindx(fileno, (struct sockaddr *) addrs, num_ip, flags) != 0)
@@ -466,6 +476,9 @@ static VALUE rsctp_connectx(int argc, VALUE* argv, VALUE self){
     addrs[i].sin_family = NUM2INT(v_domain);
     addrs[i].sin_port = htons(NUM2INT(v_port));
     addrs[i].sin_addr.s_addr = inet_addr(StringValueCStr(v_address));
+#ifdef BSD
+    addrs[i].sin_len = sizeof(struct sockaddr_in);
+#endif
   }
 
   fileno = NUM2INT(rb_iv_get(self, "@fileno"));
@@ -993,6 +1006,9 @@ static VALUE rsctp_sendmsg(VALUE self, VALUE v_options){
       addrs[i].sin_family = NUM2INT(rb_iv_get(self, "@domain"));
       addrs[i].sin_port = htons(port);
       addrs[i].sin_addr.s_addr = inet_addr(StringValueCStr(v_address));
+#ifdef BSD
+      addrs[i].sin_len = sizeof(struct sockaddr_in);
+#endif
     }
 
     size = sizeof(addrs);

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -716,6 +716,9 @@ static VALUE rsctp_sendv(VALUE self, VALUE v_options){
       addrs[i].sin_family = domain;
       addrs[i].sin_port = htons(port);
       addrs[i].sin_addr.s_addr = inet_addr(StringValueCStr(v_address));
+#ifdef BSD
+      addrs[i].sin_len = sizeof(struct sockaddr_in);
+#endif
     }
   }
 

--- a/sctp-socket.gemspec
+++ b/sctp-socket.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'sctp-socket'
-  spec.version     = '0.1.1'
+  spec.version     = '0.1.2'
   spec.author      = 'Daniel Berger'
   spec.email       = 'djberg96@gmail.com'
   spec.summary     = 'Ruby bindings for SCTP sockets'

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -10,7 +10,7 @@ require 'sctp/socket'
 RSpec.describe SCTP::Socket do
   context "version" do
     example "version is set to the expected value" do
-      expect(SCTP::Socket::VERSION).to eq('0.1.1')
+      expect(SCTP::Socket::VERSION).to eq('0.1.2')
     end
   end
 


### PR DESCRIPTION
It turns out that BSD `sockaddr_in` structs demand a `sin_len` struct member be set. This necessitated checks for BSD via macros.

In addition, BSD flavors will use `sctp_sendmsgx` internally for the `sendmsg` method if there's more than one IP.