### PR TITLE
Allow options to close method

### DIFF
--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -504,10 +504,17 @@ static VALUE rsctp_connectx(int argc, VALUE* argv, VALUE self){
  */
 static VALUE rsctp_close(VALUE self){
   int on;
+  struct linger lin;
   int fileno = NUM2INT(rb_iv_get(self, "@fileno"));
 
   on = 1;
   if(setsockopt(fileno, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0)
+    rb_raise(rb_eSystemCallError, "setsockopt: %s", strerror(errno));
+
+  lin.l_onoff = 1;
+  lin.l_linger = 3;
+
+  if(setsockopt(fileno, SOL_SOCKET, SO_LINGER, &lin, sizeof(struct linger)) < 0)
     rb_raise(rb_eSystemCallError, "setsockopt: %s", strerror(errno));
 
   if(close(fileno))

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -503,9 +503,14 @@ static VALUE rsctp_connectx(int argc, VALUE* argv, VALUE self){
  *   socket.close
  */
 static VALUE rsctp_close(VALUE self){
-  VALUE v_fileno = rb_iv_get(self, "@fileno");
+  int on;
+  int fileno = NUM2INT(rb_iv_get(self, "@fileno"));
 
-  if(close(NUM2INT(v_fileno)))
+  on = 1;
+  if(setsockopt(fileno, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0)
+    rb_raise(rb_eSystemCallError, "setsockopt: %s", strerror(errno));
+
+  if(close(fileno))
     rb_raise(rb_eSystemCallError, "close: %s", strerror(errno));
 
   return self;

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -497,10 +497,24 @@ static VALUE rsctp_connectx(int argc, VALUE* argv, VALUE self){
  *
  * Close the socket. You should always do this.
  *
+ * By default the underlying close operation is non-blocking. This means that the
+ * bound IP addresses may not be available right away after closing. You may
+ * optionally control this behavior with two different options.
+ *
+ * * reuse_addr - If set to true, then the SO_REUSEADDR flag will be applied to
+ *     the socket. This will allow other sockets to reuse the addresses that
+ *     are currently bound to the socket.
+ *
+ * * linger - If present, this should be set to a numeric value, in seconds.
+ *     The value will cause the close operation to block for that number of
+ *     seconds, after which it will return (i.e. return to non-blocking).
+ *
  * Example:
  *
  *   socket = SCTP::Socket.new
- *   socket.close
+ *   socket.close # or
+ *   socket.close(reuse_addr: true) # or
+ *   socket.close(linger: 5)
  */
 static VALUE rsctp_close(int argc, VALUE* argv, VALUE self){
   VALUE v_options, v_reuse_addr, v_linger;

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -136,7 +136,6 @@ RSpec.describe SCTP::Socket do
       expect{ @socket.connectx(:addresses => addresses) }.to raise_error(ArgumentError)
     end
   end
-=begin
 
   context "close" do
     before do
@@ -161,8 +160,8 @@ RSpec.describe SCTP::Socket do
     let(:port){ 12345 }
 
     before do
-      @server = described_class.new
       @socket = described_class.new
+      @server = described_class.new
       @server.bindx(:addresses => addresses, :port => port)
       @server.listen
     end
@@ -176,12 +175,9 @@ RSpec.describe SCTP::Socket do
       @socket.connectx(:addresses => addresses, :port => port)
       expect(@socket.getpeernames).to eq(addresses)
     end
-
-    #example "getpeernames does not accept arguments" do
-    #  expect{ @socket.getpeernames(true) }.to raise_error(ArgumentError)
-    #end
   end
 
+=begin
   context "getlocalnames" do
     let(:addresses){ %w[1.1.1.1 1.1.1.2] }
     let(:port){ 12345 }

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -59,41 +59,53 @@ RSpec.describe SCTP::Socket do
     let(:port){ 12345 }
 
     before do
-      @socket = described_class.new
+      @server = described_class.new
     end
 
     after do
-      @socket.close if @socket
+      @server.close if @server
     end
 
     example "bindx both sets and returns port value" do
-      port = @socket.bindx
-      expect(@socket.port).to eq(port)
+      port = @server.bindx
+      expect(@server.port).to eq(port)
     end
 
     example "bindx with no arguments" do
-      expect{ @socket.bindx }.not_to raise_error
+      expect{ @server.bindx }.not_to raise_error
     end
 
     example "bindx with addresses" do
-      expect{ @socket.bindx(:addresses => addresses) }.not_to raise_error
+      expect{ @server.bindx(:addresses => addresses) }.not_to raise_error
     end
 
     example "bindx with explicit port value" do
-      expect{ @socket.bindx(:port => port) }.not_to raise_error
-      expect(@socket.port).to eq(port)
+      expect{ @server.bindx(:port => port) }.not_to raise_error
+      expect(@server.port).to eq(port)
     end
 
     example "bindx using explicit flags to add addresses" do
-      expect{ @socket.bindx(:addresses => addresses, :flags => SCTP::Socket::SCTP_BINDX_ADD_ADDR) }.not_to raise_error
+      expect{
+        @server.bindx(
+          :addresses => addresses,
+          :flags => SCTP::Socket::SCTP_BINDX_ADD_ADDR
+        )
+      }.not_to raise_error
     end
 
     xexample "bindx using explicit flags to remove addresses" do
-      @socket.bindx(:port => port, :addresses => addresses)
-      expect{ @socket.bindx(:port => port, :addresses => [addresses.last], :flags => SCTP::Socket::SCTP_BINDX_REM_ADDR) }.not_to raise_error
+      @server.bindx(:port => port, :addresses => addresses)
+      expect{
+        @server.bindx(
+          :port => port,
+          :addresses => [addresses.last],
+          :flags => SCTP::Socket::SCTP_BINDX_REM_ADDR
+        )
+      }.not_to raise_error
     end
   end
 
+=begin
   context "connectx" do
     let(:addresses){ %w[1.1.1.1 1.1.1.2] }
     let(:port){ 12345 }
@@ -275,4 +287,5 @@ RSpec.describe SCTP::Socket do
       expect{ @server.get_subscriptions(true) }.to raise_error(ArgumentError)
     end
   end
+=end
 end

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -8,6 +8,9 @@ require 'socket'
 require 'sctp/socket'
 
 RSpec.describe SCTP::Socket do
+  let(:addresses){ %w[1.1.1.1 1.1.1.2] }
+  let(:port){ 12345 }
+
   context "version" do
     example "version is set to the expected value" do
       expect(SCTP::Socket::VERSION).to eq('0.1.2')
@@ -55,9 +58,6 @@ RSpec.describe SCTP::Socket do
   end
 
   context "bindx" do
-    let(:addresses){ %w[1.1.1.1 1.1.1.2] }
-    let(:port){ 12345 }
-
     before do
       @server = described_class.new
     end
@@ -106,9 +106,6 @@ RSpec.describe SCTP::Socket do
   end
 
   context "connectx" do
-    let(:addresses){ %w[1.1.1.1 1.1.1.2] }
-    let(:port){ 12345 }
-
     before do
       @socket = described_class.new
       @server = described_class.new
@@ -156,9 +153,6 @@ RSpec.describe SCTP::Socket do
   end
 
   context "getpeernames" do
-    let(:addresses){ %w[1.1.1.1 1.1.1.2] }
-    let(:port){ 12345 }
-
     before do
       @socket = described_class.new
       @server = described_class.new
@@ -167,6 +161,7 @@ RSpec.describe SCTP::Socket do
     end
 
     after do
+      @server.shutdown rescue nil
       @socket.close if @socket
       @server.close if @server
     end
@@ -178,9 +173,6 @@ RSpec.describe SCTP::Socket do
   end
 
   context "getlocalnames" do
-    let(:addresses){ %w[1.1.1.1 1.1.1.2] }
-    let(:port){ 12345 }
-
     before do
       @server = described_class.new
       @socket = described_class.new
@@ -189,6 +181,7 @@ RSpec.describe SCTP::Socket do
     end
 
     after do
+      @server.shutdown rescue nil
       @socket.close if @socket
       @server.close if @server
     end
@@ -200,16 +193,11 @@ RSpec.describe SCTP::Socket do
     end
   end
 
-=begin
   context "get_status" do
-    let(:addresses){ %w[1.1.1.1 1.1.1.2] }
-    let(:port){ 12345 }
-
     before do
       @server = described_class.new
       @socket = described_class.new
       @server.bindx(:addresses => addresses, :port => port)
-      @server.listen
       @socket.connectx(:addresses => addresses, :port => port)
     end
 
@@ -235,6 +223,7 @@ RSpec.describe SCTP::Socket do
       expect(struct.primary).to eq(addresses.first)
     end
   end
+=begin
 
   context "subscribe" do
     let(:addresses){ %w[1.1.1.1 1.1.1.2] }

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -177,7 +177,6 @@ RSpec.describe SCTP::Socket do
     end
   end
 
-=begin
   context "getlocalnames" do
     let(:addresses){ %w[1.1.1.1 1.1.1.2] }
     let(:port){ 12345 }
@@ -196,14 +195,11 @@ RSpec.describe SCTP::Socket do
 
     example "getlocalnames returns the expected array" do
       @socket.connectx(:addresses => addresses, :port => port)
-      expect(@socket.getlocalnames).to eq(addresses)
+      expect(@socket.getlocalnames).to include(*addresses)
     end
-
-    #example "getlocalnames does not accept arguments" do
-    #  expect{ @socket.getlocalnames(true) }.to raise_error(ArgumentError)
-    #end
   end
 
+=begin
   context "get_status" do
     let(:addresses){ %w[1.1.1.1 1.1.1.2] }
     let(:port){ 12345 }

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe SCTP::Socket do
       @server.close if @server
     end
 
+    # TODO: FreeBSD is picking up localhost and em0 here, is that normal?
     example "getlocalnames returns the expected array" do
       @socket.connectx(:addresses => addresses, :port => port)
       expect(@socket.getlocalnames).to include(*addresses)

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -208,27 +208,35 @@ RSpec.describe SCTP::Socket do
     end
   end
 
-=begin
   context "close" do
+    before do
+      @csocket = described_class.new
+      @cserver = described_class.new
+    end
+
+    after do
+      @csocket.close if @csocket rescue nil
+      @cserver.close if @cserver rescue nil
+    end
+
     example "close basic functionality" do
-      expect{ @socket.close }.not_to raise_error
+      expect{ @csocket.close }.not_to raise_error
     end
 
     example "close argument if present must be a Hash" do
-      expect{ @socket.close(1) }.to raise_error(TypeError)
+      expect{ @csocket.close(1) }.to raise_error(TypeError)
     end
 
     example "calling close on a closed socket raises an error" do
-      expect{ 2.times{ @socket.close } }.to raise_error(SystemCallError)
+      expect{ 2.times{ @csocket.close } }.to raise_error(SystemCallError)
     end
 
     example "close accepts a reuse_addr argument" do
-      expect{ @socket.close(reuse_addr: true) }.not_to raise_error
+      expect{ @csocket.close(reuse_addr: true) }.not_to raise_error
     end
 
     example "close accepts a linger argument" do
-      expect{ @socket.close(linger: 10) }.not_to raise_error
+      expect{ @csocket.close(linger: 10) }.not_to raise_error
     end
   end
-=end
 end

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -11,265 +11,223 @@ RSpec.describe SCTP::Socket do
   let(:addresses){ %w[1.1.1.1 1.1.1.2] }
   let(:port){ 12345 }
 
-  context "version" do
-    example "version is set to the expected value" do
-      expect(SCTP::Socket::VERSION).to eq('0.1.2')
-    end
-  end
-
-  context "constructor" do
-    before do
-      @socket = nil
-    end
-
-    after do
-      @socket.close if @socket
-    end
-
-    example "constructor with no arguments" do
-      expect{ @socket = described_class.new }.not_to raise_error
-      expect(@socket.domain).to eq(Socket::AF_INET)
-      expect(@socket.type).to eq(Socket::SOCK_SEQPACKET)
-    end
-
-    example "constructor with domain argument" do
-      expect{ @socket = described_class.new(Socket::AF_INET6) }.not_to raise_error
-      expect(@socket.domain).to eq(Socket::AF_INET6)
-    end
-
-    example "constructor with type argument" do
-      expect{ @socket = described_class.new(Socket::AF_INET, Socket::SOCK_STREAM) }.not_to raise_error
-      expect(@socket.type).to eq(Socket::SOCK_STREAM)
-    end
-
-    example "constructor only accepts two arguments" do
-      expect{ described_class.new(Socket::AF_INET, Socket::SOCK_STREAM, 0) }.to raise_error(ArgumentError)
-    end
-
-    example "fileno has expected value" do
-      @socket = described_class.new
-      expect(@socket.fileno).to be_a(Integer)
-    end
-
-    example "association_id has expected value" do
-      @socket = described_class.new
-      expect(@socket.association_id).to eq(0)
-    end
-  end
-
-  context "bindx" do
-    before do
-      @server = described_class.new
-    end
-
-    after do
-      @server.close if @server
-    end
-
-    example "bindx both sets and returns port value" do
-      port = @server.bindx
-      expect(@server.port).to eq(port)
-    end
-
-    example "bindx with no arguments" do
-      expect{ @server.bindx }.not_to raise_error
-    end
-
-    example "bindx with addresses" do
-      expect{ @server.bindx(:addresses => addresses) }.not_to raise_error
-    end
-
-    example "bindx with explicit port value" do
-      expect{ @server.bindx(:port => port) }.not_to raise_error
-      expect(@server.port).to eq(port)
-    end
-
-    example "bindx using explicit flags to add addresses" do
-      expect{
-        @server.bindx(
-          :addresses => addresses,
-          :flags => SCTP::Socket::SCTP_BINDX_ADD_ADDR
-        )
-      }.not_to raise_error
-    end
-
-    xexample "bindx using explicit flags to remove addresses" do
-      @server.bindx(:port => port, :addresses => addresses)
-      expect{
-        @server.bindx(
-          :port => port,
-          :addresses => [addresses.last],
-          :flags => SCTP::Socket::SCTP_BINDX_REM_ADDR
-        )
-      }.not_to raise_error
-    end
-  end
-
-  context "connectx" do
+  describe 'most methods' do
     before do
       @socket = described_class.new
       @server = described_class.new
-      @server.bindx(:port => port)
-      @server.listen
     end
 
     after do
-      @socket.close if @socket
-      @server.close if @server
+      @socket.close(reuse_addr: true, linger: 0) if @socket
+      @server.close(reuse_addr: true, linger: 0) if @server
     end
 
-    example "connectx basic check" do
-      expect{ @socket.connectx(:addresses => addresses, :port => port) }.not_to raise_error
+    context "version" do
+      example "version is set to the expected value" do
+        expect(SCTP::Socket::VERSION).to eq('0.1.2')
+      end
     end
 
-    example "association ID is set after connectx" do
-      @socket.connectx(:addresses => addresses, :port => port)
-      expect(@socket.association_id).to be > 0
+    context "constructor" do
+      example "constructor with no arguments" do
+        expect{ @socket = described_class.new }.not_to raise_error
+        expect(@socket.domain).to eq(Socket::AF_INET)
+        expect(@socket.type).to eq(Socket::SOCK_SEQPACKET)
+      end
+
+      example "constructor with domain argument" do
+        expect{ @socket = described_class.new(Socket::AF_INET6) }.not_to raise_error
+        expect(@socket.domain).to eq(Socket::AF_INET6)
+      end
+
+      example "constructor with type argument" do
+        expect{ @socket = described_class.new(Socket::AF_INET, Socket::SOCK_STREAM) }.not_to raise_error
+        expect(@socket.type).to eq(Socket::SOCK_STREAM)
+      end
+
+      example "constructor only accepts two arguments" do
+        expect{ described_class.new(Socket::AF_INET, Socket::SOCK_STREAM, 0) }.to raise_error(ArgumentError)
+      end
+
+      example "fileno has expected value" do
+        expect(@socket.fileno).to be_a(Integer)
+      end
+
+      example "association_id has expected value" do
+        expect(@socket.association_id).to eq(0)
+      end
     end
 
-    example "connectx requires both a port and an array of addresses" do
-      expect{ @socket.connectx }.to raise_error(ArgumentError)
-      expect{ @socket.connectx(:port => port) }.to raise_error(ArgumentError)
-      expect{ @socket.connectx(:addresses => addresses) }.to raise_error(ArgumentError)
+    context "bindx" do
+      example "bindx both sets and returns port value" do
+        port = @server.bindx
+        expect(@server.port).to eq(port)
+      end
+
+      example "bindx with no arguments" do
+        expect{ @server.bindx }.not_to raise_error
+      end
+
+      example "bindx with addresses" do
+        expect{ @server.bindx(:addresses => addresses) }.not_to raise_error
+      end
+
+      example "bindx with explicit port value" do
+        expect{ @server.bindx(:port => port) }.not_to raise_error
+        expect(@server.port).to eq(port)
+      end
+
+      example "bindx using explicit flags to add addresses" do
+        expect{
+          @server.bindx(
+            :addresses => addresses,
+            :flags => SCTP::Socket::SCTP_BINDX_ADD_ADDR
+          )
+        }.not_to raise_error
+      end
+
+      xexample "bindx using explicit flags to remove addresses" do
+        @server.bindx(:port => port, :addresses => addresses)
+        expect{
+          @server.bindx(
+            :port => port,
+            :addresses => [addresses.last],
+            :flags => SCTP::Socket::SCTP_BINDX_REM_ADDR
+          )
+        }.not_to raise_error
+      end
+    end
+
+    context "connectx" do
+      before do
+        @server.bindx(:port => port)
+        @server.listen
+      end
+
+      example "connectx basic check" do
+        expect{ @socket.connectx(:addresses => addresses, :port => port) }.not_to raise_error
+      end
+
+      example "association ID is set after connectx" do
+        @socket.connectx(:addresses => addresses, :port => port)
+        expect(@socket.association_id).to be > 0
+      end
+
+      example "connectx requires both a port and an array of addresses" do
+        expect{ @socket.connectx }.to raise_error(ArgumentError)
+        expect{ @socket.connectx(:port => port) }.to raise_error(ArgumentError)
+        expect{ @socket.connectx(:addresses => addresses) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "getpeernames" do
+      before do
+        @server.bindx(:addresses => addresses, :port => port)
+        @server.listen
+      end
+
+      example "getpeernames returns the expected array" do
+        @socket.connectx(:addresses => addresses, :port => port)
+        expect(@socket.getpeernames).to eq(addresses)
+      end
+    end
+
+    context "getlocalnames" do
+      before do
+        @server.bindx(:addresses => addresses, :port => port)
+        @server.listen
+      end
+
+      # TODO: FreeBSD is picking up localhost and em0 here, is that normal?
+      example "getlocalnames returns the expected array" do
+        @socket.connectx(:addresses => addresses, :port => port)
+        expect(@socket.getlocalnames).to include(*addresses)
+      end
+    end
+
+    context "get_status" do
+      before do
+        @server.bindx(:addresses => addresses, :port => port)
+        @socket.connectx(:addresses => addresses, :port => port)
+      end
+
+      example "get_status return the expected struct" do
+        expect(@socket.get_status).to be_a(Struct::Status)
+      end
+
+      example "status struct contains expected values" do
+        struct = @socket.get_status
+        expect(struct.association_id).to be_a(Integer)
+        expect(struct.state).to be_a(Integer)
+        expect(struct.receive_window).to be_a(Integer)
+        expect(struct.unacknowledged_data).to be_a(Integer)
+        expect(struct.pending_data).to be_a(Integer)
+        expect(struct.inbound_streams).to be_a(Integer)
+        expect(struct.outbound_streams).to be_a(Integer)
+        expect(struct.fragmentation_point).to be_a(Integer)
+        expect(struct.primary).to eq(addresses.first)
+      end
+    end
+
+    context "subscribe" do
+      let(:addresses){ %w[1.1.1.1 1.1.1.2] }
+      let(:port){ 12345 }
+
+      before do
+        @server.bindx(:addresses => addresses, :port => port)
+        @server.listen
+      end
+
+      example "subscribe accepts a hash of options" do
+        expect{ @server.subscribe(:data_io => true) }.not_to raise_error
+        expect{ @server.subscribe(1) }.to raise_error(TypeError)
+      end
+    end
+
+    context "get_subscriptions" do
+      let(:addresses){ %w[1.1.1.1 1.1.1.2] }
+      let(:port){ 12345 }
+      let(:subscriptions){ {:data_io => true, :shutdown => true} }
+
+      before do
+        @server.bindx(:addresses => addresses, :port => port)
+        @server.subscribe(subscriptions)
+      end
+
+      example "get_subscriptions returns expected values" do
+        subscriptions = @server.get_subscriptions
+        expect(subscriptions[:data_io]).to be true
+        expect(subscriptions[:shutdown]).to be true
+        expect(subscriptions[:association]).to be false
+        expect(subscriptions[:authentication]).to be false
+      end
+
+      example "get_subscriptions does not accept any arguments" do
+        expect{ @server.get_subscriptions(true) }.to raise_error(ArgumentError)
+      end
     end
   end
 
+=begin
   context "close" do
-    before do
-      @socket = described_class.new
-    end
-
     example "close basic functionality" do
       expect{ @socket.close }.not_to raise_error
     end
 
-    example "close does not take any arguments" do
-      expect{ @socket.close(1) }.to raise_error(ArgumentError)
+    example "close argument if present must be a Hash" do
+      expect{ @socket.close(1) }.to raise_error(TypeError)
     end
 
     example "calling close on a closed socket raises an error" do
       expect{ 2.times{ @socket.close } }.to raise_error(SystemCallError)
     end
-  end
 
-  context "getpeernames" do
-    before do
-      @socket = described_class.new
-      @server = described_class.new
-      @server.bindx(:addresses => addresses, :port => port)
-      @server.listen
+    example "close accepts a reuse_addr argument" do
+      expect{ @socket.close(reuse_addr: true) }.not_to raise_error
     end
 
-    after do
-      @server.shutdown rescue nil
-      @socket.close if @socket
-      @server.close if @server
-    end
-
-    example "getpeernames returns the expected array" do
-      @socket.connectx(:addresses => addresses, :port => port)
-      expect(@socket.getpeernames).to eq(addresses)
-    end
-  end
-
-  context "getlocalnames" do
-    before do
-      @server = described_class.new
-      @socket = described_class.new
-      @server.bindx(:addresses => addresses, :port => port)
-      @server.listen
-    end
-
-    after do
-      @server.shutdown rescue nil
-      @socket.close if @socket
-      @server.close if @server
-    end
-
-    # TODO: FreeBSD is picking up localhost and em0 here, is that normal?
-    example "getlocalnames returns the expected array" do
-      @socket.connectx(:addresses => addresses, :port => port)
-      expect(@socket.getlocalnames).to include(*addresses)
-    end
-  end
-
-  context "get_status" do
-    before do
-      @server = described_class.new
-      @socket = described_class.new
-      @server.bindx(:addresses => addresses, :port => port)
-      @socket.connectx(:addresses => addresses, :port => port)
-    end
-
-    after do
-      @socket.close if @socket
-      @server.close if @server
-    end
-
-    example "get_status return the expected struct" do
-      expect(@socket.get_status).to be_a(Struct::Status)
-    end
-
-    example "status struct contains expected values" do
-      struct = @socket.get_status
-      expect(struct.association_id).to be_a(Integer)
-      expect(struct.state).to be_a(Integer)
-      expect(struct.receive_window).to be_a(Integer)
-      expect(struct.unacknowledged_data).to be_a(Integer)
-      expect(struct.pending_data).to be_a(Integer)
-      expect(struct.inbound_streams).to be_a(Integer)
-      expect(struct.outbound_streams).to be_a(Integer)
-      expect(struct.fragmentation_point).to be_a(Integer)
-      expect(struct.primary).to eq(addresses.first)
-    end
-  end
-=begin
-
-  context "subscribe" do
-    let(:addresses){ %w[1.1.1.1 1.1.1.2] }
-    let(:port){ 12345 }
-
-    before do
-      @server = described_class.new
-      @server.bindx(:addresses => addresses, :port => port)
-      @server.listen
-    end
-
-    after do
-      @server.close if @server
-    end
-
-    example "subscribe accepts a hash of options" do
-      expect{ @server.subscribe(:data_io => true) }.not_to raise_error
-      expect{ @server.subscribe(1) }.to raise_error(TypeError)
-    end
-  end
-
-  context "get_subscriptions" do
-    let(:addresses){ %w[1.1.1.1 1.1.1.2] }
-    let(:port){ 12345 }
-    let(:subscriptions){ {:data_io => true, :shutdown => true} }
-
-    before do
-      @server = described_class.new
-      @server.bindx(:addresses => addresses, :port => port)
-      @server.subscribe(subscriptions)
-    end
-
-    after do
-      @server.close if @server
-    end
-
-    example "get_subscriptions returns expected values" do
-      subscriptions = @server.get_subscriptions
-      expect(subscriptions[:data_io]).to be true
-      expect(subscriptions[:shutdown]).to be true
-      expect(subscriptions[:association]).to be false
-      expect(subscriptions[:authentication]).to be false
-    end
-
-    example "get_subscriptions does not accept any arguments" do
-      expect{ @server.get_subscriptions(true) }.to raise_error(ArgumentError)
+    example "close accepts a linger argument" do
+      expect{ @socket.close(linger: 10) }.not_to raise_error
     end
   end
 =end

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -105,18 +105,20 @@ RSpec.describe SCTP::Socket do
     end
   end
 
-=begin
   context "connectx" do
     let(:addresses){ %w[1.1.1.1 1.1.1.2] }
     let(:port){ 12345 }
 
     before do
       @socket = described_class.new
-      @socket.bindx(:port => port)
+      @server = described_class.new
+      @server.bindx(:port => port)
+      @server.listen
     end
 
     after do
       @socket.close if @socket
+      @server.close if @server
     end
 
     example "connectx basic check" do
@@ -134,6 +136,7 @@ RSpec.describe SCTP::Socket do
       expect{ @socket.connectx(:addresses => addresses) }.to raise_error(ArgumentError)
     end
   end
+=begin
 
   context "close" do
     before do

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe SCTP::Socket do
     context "get_status" do
       before do
         @server.bindx(:addresses => addresses, :port => port)
+        @server.listen
         @socket.connectx(:addresses => addresses, :port => port)
       end
 


### PR DESCRIPTION
This PR modifies the `close` method to accept options to control how exactly the underlying function behaves.

I also reworked the specs in preparation for BSD support.