### PR TITLE
Add more sockopts

### DIFF
--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe SCTP::Socket do
       end
     end
 
-    context "get_status" do
+    context "get_retransmission_info" do
       before do
         @server.bindx(:addresses => addresses, :port => port, :reuse_addr => true)
         @server.listen
@@ -229,6 +229,28 @@ RSpec.describe SCTP::Socket do
 
       example "get_rto_info is an alias for get_retransmission_info" do
         expect(@server.method(:get_rto_info)).to eq(@server.method(:get_retransmission_info))
+      end
+    end
+
+    context "get_association_info" do
+      before do
+        @server.bindx(:addresses => addresses, :port => port, :reuse_addr => true)
+        @server.listen
+        @socket.connectx(:addresses => addresses, :port => port, :reuse_addr => true)
+      end
+
+      example "get_association_info returns expected value" do
+        info = @server.get_association_info
+        expect(info.association_id).to be_a(Integer)
+        expect(info.max_retransmission_count).to be_a(Integer)
+        expect(info.number_peer_destinations).to be_a(Integer)
+        expect(info.peer_receive_window).to be_a(Integer)
+        expect(info.local_receive_window).to be_a(Integer)
+        expect(info.cookie_life).to be_a(Integer)
+      end
+
+      example "get_association_info does not accept any arguments" do
+        expect{ @server.get_association_info(true) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/sctp_spec.rb
+++ b/spec/sctp_spec.rb
@@ -176,9 +176,6 @@ RSpec.describe SCTP::Socket do
     end
 
     context "subscribe" do
-      let(:addresses){ %w[1.1.1.1 1.1.1.2] }
-      let(:port){ 12345 }
-
       before do
         @server.bindx(:addresses => addresses, :port => port, :reuse_addr => true)
         @server.listen
@@ -191,8 +188,6 @@ RSpec.describe SCTP::Socket do
     end
 
     context "get_subscriptions" do
-      let(:addresses){ %w[1.1.1.1 1.1.1.2] }
-      let(:port){ 12345 }
       let(:subscriptions){ {:data_io => true, :shutdown => true} }
 
       before do
@@ -210,6 +205,30 @@ RSpec.describe SCTP::Socket do
 
       example "get_subscriptions does not accept any arguments" do
         expect{ @server.get_subscriptions(true) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "get_status" do
+      before do
+        @server.bindx(:addresses => addresses, :port => port, :reuse_addr => true)
+        @server.listen
+        @socket.connectx(:addresses => addresses, :port => port, :reuse_addr => true)
+      end
+
+      example "get_retransmission_info returns expected value" do
+        info = @server.get_retransmission_info
+        expect(info.association_id).to be_a(Integer)
+        expect(info.min).to be_a(Integer)
+        expect(info.max).to be_a(Integer)
+        expect(info.initial).to be_a(Integer)
+      end
+
+      example "get_retransmission_info does not accept any arguments" do
+        expect{ @server.get_retransmission_info(true) }.to raise_error(ArgumentError)
+      end
+
+      example "get_rto_info is an alias for get_retransmission_info" do
+        expect(@server.method(:get_rto_info)).to eq(@server.method(:get_retransmission_info))
       end
     end
   end


### PR DESCRIPTION
This adds the `set_retransmission_info`, and adds the `get_rto_info` and `set_rto_info` aliases. It also adds the `set_association_info` method, and adds some specs.