### PR TITLE
Add server class

### DIFF
--- a/examples/client_for_server_test.rb
+++ b/examples/client_for_server_test.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+require 'sctp/socket'
+
+# Simple SCTP client to test with the server
+
+puts "SCTP Client Example"
+puts "==================="
+
+begin
+  # Connect to the server
+  client = SCTP::Socket.new
+  client.connectx(addresses: ['127.0.0.1'], port: 9999)
+
+  puts "Connected to server at 127.0.0.1:9999"
+
+  # Send a few test messages
+  ["Hello, SCTP!", "How are you?", "Goodbye!"].each_with_index do |message, i|
+    puts "Sending: #{message}"
+    client.sendmsg(message: message, stream: i % 3)  # Use different streams
+
+    # Receive the echo
+    data, info = client.recvmsg
+    puts "Received: #{data.inspect} on stream #{info.stream}"
+
+    sleep 1
+  end
+
+rescue => e
+  puts "Error: #{e.message}"
+ensure
+  client.close if client
+  puts "Client closed"
+end

--- a/examples/sctp_server_example.rb
+++ b/examples/sctp_server_example.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# Example SCTP server using the SCTP::Server class
+# Run with: ruby -I lib examples/sctp_server_example.rb
+
+require 'sctp/socket'
+
+puts "SCTP::Server Example"
+puts "==================="
+
+# Example 1: One-to-many server (default mode)
+puts "\n1. One-to-many server example:"
+puts "   Multiple clients can connect to the same server socket"
+puts "   All communication happens through the main server socket"
+
+server = SCTP::Server.new(['127.0.0.1'], 9999)
+puts "   Server listening on: #{server}"
+
+# Simulate server operation (normally you'd have a loop here)
+puts "   Server ready to receive messages with server.recvmsg"
+puts "   Send messages back with server.sendmsg(data, association_id: id)"
+
+server.close
+puts "   Server closed"
+
+# Example 2: One-to-one server with peeloff
+puts "\n2. One-to-one server example:"
+puts "   Each client connection gets its own dedicated socket"
+puts "   Uses peeloff() to create individual sockets per association"
+
+server_1to1 = SCTP::Server.new(['127.0.0.1'], 9998, one_to_one: true)
+puts "   Server listening on: #{server_1to1}"
+
+# Simulate server operation
+puts "   Server ready to accept connections with server.accept"
+puts "   Each accepted connection returns a new SCTP::Socket"
+puts "   Handle each client in a separate thread"
+
+server_1to1.close
+puts "   Server closed"
+
+# Example 3: Server with multiple addresses (multihoming)
+puts "\n3. Multihomed server example:"
+puts "   SCTP supports binding to multiple IP addresses"
+
+begin
+  # This will work if you have multiple addresses configured
+  multi_server = SCTP::Server.new(['127.0.0.1', '127.0.0.2'], 9997)
+  puts "   Multihomed server: #{multi_server}"
+  multi_server.close
+rescue => e
+  puts "   Multihomed server failed (expected if addresses not configured): #{e.message}"
+end
+
+# Example 4: Server with custom options
+puts "\n4. Server with custom options:"
+
+custom_server = SCTP::Server.new(['127.0.0.1'], 9996,
+  backlog: 64,
+  autoclose: 10,
+  init_msg: { output_streams: 10, input_streams: 10 }
+)
+puts "   Custom server: #{custom_server}"
+custom_server.close
+
+puts "\nExample complete!"
+puts "\nTo test with a real client:"
+puts "1. Start the server in one terminal"
+puts "2. Use examples/client_example.rb to connect"
+puts "3. Or create a simple client with SCTP::Socket.new and connectx()"

--- a/examples/server_using_sctp_server.rb
+++ b/examples/server_using_sctp_server.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+
+require 'sctp/socket'
+
+# Simple SCTP echo server example using SCTP::Server
+
+puts "SCTP Echo Server Example"
+puts "========================"
+
+# Create a server that binds to localhost on port 9999
+server = SCTP::Server.new(['127.0.0.1'], 9999)
+
+puts "Server listening on #{server.addr.join(', ')}:#{server.local_port}"
+puts "Mode: #{server.one_to_one ? 'one-to-one' : 'one-to-many'}"
+puts "Press Ctrl+C to stop"
+
+begin
+  if server.one_to_one
+    # One-to-one mode: accept individual connections
+    puts "Waiting for connections..."
+    loop do
+      client = server.accept
+      puts "Accepted connection from association #{client.initial_message[1].association_id}"
+
+      # Handle the connection in a thread
+      Thread.new(client) do |c|
+        begin
+          # Get the initial message that triggered the connection
+          data, info = c.initial_message
+          puts "Initial message: #{data.inspect}"
+
+          # Echo it back
+          c.sendmsg("Echo: #{data}")
+
+          # Continue receiving messages
+          loop do
+            data, info = c.recvmsg
+            puts "Received: #{data.inspect}"
+            c.sendmsg("Echo: #{data}")
+          end
+        rescue => e
+          puts "Client connection error: #{e.message}"
+        ensure
+          c.close
+          puts "Client disconnected"
+        end
+      end
+    end
+  else
+    # One-to-many mode: handle all connections on the same socket
+    puts "Waiting for messages..."
+    loop do
+      data, info = server.recvmsg
+      puts "Received from association #{info.association_id}: #{data.inspect}"
+
+      # Echo the message back to the sender
+      server.sendmsg("Echo: #{data}", association_id: info.association_id)
+    end
+  end
+rescue Interrupt
+  puts "\nShutting down server..."
+ensure
+  server.close
+  puts "Server closed"
+end

--- a/lib/sctp/server.rb
+++ b/lib/sctp/server.rb
@@ -1,0 +1,207 @@
+require 'socket'
+require 'sctp/socket'
+
+module SCTP
+  # SCTP::Server provides a TCPServer-like interface for SCTP sockets.
+  #
+  # Unlike TCP which uses accept() to create new sockets for each connection,
+  # SCTP can operate in one-to-many mode where a single socket handles
+  # multiple associations. This server class provides both modes:
+  #
+  # 1. One-to-many mode (default): All connections share the server socket
+  # 2. One-to-one mode: Uses peeloff() to create individual sockets per association
+  #
+  # Example usage:
+  #
+  #   # Basic one-to-many server
+  #   server = SCTP::Server.new(['127.0.0.1'], 9999)
+  #   loop do
+  #     data, info = server.recvmsg
+  #     puts "Received: #{data} from association #{info.association_id}"
+  #     server.sendmsg("Echo: #{data}", association_id: info.association_id)
+  #   end
+  #
+  #   # One-to-one server with peeloff
+  #   server = SCTP::Server.new(['127.0.0.1'], 9999, one_to_one: true)
+  #   loop do
+  #     client = server.accept  # Returns a new SCTP::Socket for the association
+  #     Thread.new(client) do |c|
+  #       data, info = c.recvmsg
+  #       c.sendmsg("Echo: #{data}")
+  #       c.close
+  #     end
+  #   end
+  #
+  class Server
+    attr_reader :socket, :addresses, :port, :one_to_one
+
+    # Create a new SCTP server.
+    #
+    # @param addresses [Array<String>, String, nil] IP addresses to bind to.
+    #   If nil, binds to all available addresses.
+    # @param port [Integer] Port number to bind to
+    # @param one_to_one [Boolean] If true, uses one-to-one mode with peeloff.
+    #   If false (default), uses one-to-many mode.
+    # @param backlog [Integer] Listen backlog (default: 128)
+    # @param socket_options [Hash] Additional socket options
+    def initialize(addresses = nil, port = 0, one_to_one: false, backlog: 128, **socket_options)
+      @addresses = Array(addresses) if addresses
+      @port = port
+      @one_to_one = one_to_one
+      @backlog = backlog
+      @socket_options = socket_options
+      @pending_associations = {}
+
+      # Create the main server socket
+      if one_to_one
+        @socket = SCTP::Socket.new(2, 1)  # AF_INET, SOCK_STREAM
+      else
+        @socket = SCTP::Socket.new(2, 5)  # AF_INET, SOCK_SEQPACKET
+      end
+
+      setup_socket
+      bind_and_listen
+    end
+
+    # Accept a new association (one-to-one mode only).
+    #
+    # In one-to-many mode, this method is not used. Instead, use recvmsg
+    # to receive data from any association.
+    #
+    # @return [SCTP::Socket] A new socket for the accepted association
+    # @raise [RuntimeError] If not in one-to-one mode
+    def accept
+      raise "accept() only available in one-to-one mode" unless @one_to_one
+
+      # Wait for a message to establish an association
+      data, info = @socket.recvmsg
+      association_id = info.association_id
+
+      # Check if we already have a peeled-off socket for this association
+      if @pending_associations[association_id]
+        client_socket = @pending_associations.delete(association_id)
+      else
+        # Peeloff a new socket for this association
+        client_socket = @socket.peeloff(association_id)
+      end
+
+      # Store the initial message in the client socket for retrieval
+      client_socket.instance_variable_set(:@initial_message, [data, info])
+
+      # Add a method to retrieve the initial message
+      def client_socket.initial_message
+        @initial_message
+      end
+
+      client_socket
+    end
+
+    # Receive a message from any association (one-to-many mode).
+    #
+    # @param flags [Integer] Receive flags (default: 0)
+    # @return [Array<String, Struct>] Message data and info struct
+    def recvmsg(flags = 0)
+      @socket.recvmsg(flags)
+    end
+
+    # Send a message to a specific association (one-to-many mode).
+    #
+    # @param data [String] Data to send
+    # @param options [Hash] Send options including :association_id
+    # @return [Integer] Number of bytes sent
+    def sendmsg(data, **options)
+      @socket.sendmsg(options.merge(message: data))
+    end
+
+    # Get local addresses bound to this server.
+    #
+    # @return [Array<String>] Local addresses
+    def addr
+      @socket.getlocalnames
+    end
+
+    # Get the local port number.
+    #
+    # @return [Integer] Port number
+    def local_port
+      @socket.port
+    end
+
+    # Check if the server is closed.
+    #
+    # @return [Boolean] true if closed, false otherwise
+    def closed?
+      @socket.closed?
+    end
+
+    # Close the server socket.
+    #
+    # @param options [Hash] Close options (e.g., linger: seconds)
+    def close(**options)
+      @socket.close(options) unless closed?
+    end
+
+    # Get server socket information.
+    #
+    # @return [String] String representation of the server
+    def to_s
+      if closed?
+        "#<SCTP::Server:closed>"
+      else
+        mode = @one_to_one ? "one-to-one" : "one-to-many"
+        "#<SCTP::Server:#{addr.join(',')}:#{local_port} (#{mode})>"
+      end
+    end
+
+    alias_method :inspect, :to_s
+
+    private
+
+    def setup_socket
+      # Apply any socket options provided
+      @socket_options.each do |option, value|
+        case option
+        when :reuse_addr
+          # SCTP typically doesn't need SO_REUSEADDR like TCP
+          # but we can support it for compatibility
+        when :autoclose
+          @socket.autoclose = value
+        when :nodelay
+          @socket.nodelay = value
+        when :init_msg
+          @socket.set_initmsg(value)
+        when :subscriptions
+          @socket.subscribe(value)
+        else
+          # For any other options, try to call them as methods
+          if @socket.respond_to?("#{option}=")
+            @socket.send("#{option}=", value)
+          end
+        end
+      end
+
+      # Set up default subscriptions for server operation
+      @socket.subscribe(
+        data_io: true,
+        association: true,
+        address: true,
+        send_failure: true,
+        shutdown: true
+      )
+    end
+
+    def bind_and_listen
+      if @addresses && !@addresses.empty?
+        @socket.bindx(port: @port, addresses: @addresses, reuse_addr: true)
+      else
+        # Bind to all available addresses
+        @socket.bindx(port: @port, reuse_addr: true)
+      end
+
+      @socket.listen(@backlog)
+
+      # Update port if it was auto-assigned (port 0)
+      @port = @socket.port if @port == 0
+    end
+  end
+end

--- a/lib/sctp/socket.rb
+++ b/lib/sctp/socket.rb
@@ -1,0 +1,2 @@
+require 'sctp/socket.so'
+require 'sctp/server'

--- a/spec/sctp_server_spec.rb
+++ b/spec/sctp_server_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper'
+require 'sctp/socket'
+
+RSpec.describe SCTP::Server do
+  describe '#initialize' do
+    it 'creates a server with default options' do
+      server = SCTP::Server.new(['127.0.0.1'], 0)
+      expect(server).to be_a(SCTP::Server)
+      expect(server.addresses).to eq(['127.0.0.1'])
+      expect(server.port).to be > 0  # Auto-assigned port
+      expect(server.one_to_one).to be false
+      server.close
+    end
+
+    it 'creates a server in one-to-one mode' do
+      server = SCTP::Server.new(['127.0.0.1'], 0, one_to_one: true)
+      expect(server.one_to_one).to be true
+      server.close
+    end
+
+    it 'auto-assigns a port when port is 0' do
+      server = SCTP::Server.new(['127.0.0.1'], 0)
+      expect(server.port).to be > 0
+      expect(server.local_port).to eq(server.port)
+      server.close
+    end
+
+    it 'binds to all addresses when addresses is nil' do
+      server = SCTP::Server.new(nil, 0)
+      expect(server.addresses).to be_nil
+      server.close
+    end
+  end
+
+  describe '#addr' do
+    it 'returns the bound addresses' do
+      server = SCTP::Server.new(['127.0.0.1'], 0)
+      addresses = server.addr
+      expect(addresses).to be_an(Array)
+      expect(addresses).to include('127.0.0.1')
+      server.close
+    end
+  end
+
+  describe '#local_port' do
+    it 'returns the bound port number' do
+      server = SCTP::Server.new(['127.0.0.1'], 0)
+      port = server.local_port
+      expect(port).to be_an(Integer)
+      expect(port).to be > 0
+      server.close
+    end
+  end
+
+  describe '#closed?' do
+    it 'returns false for open server' do
+      server = SCTP::Server.new(['127.0.0.1'], 0)
+      expect(server.closed?).to be false
+      server.close
+    end
+
+    it 'returns true after closing' do
+      server = SCTP::Server.new(['127.0.0.1'], 0)
+      server.close
+      expect(server.closed?).to be true
+    end
+  end
+
+  describe '#close' do
+    it 'closes the server socket' do
+      server = SCTP::Server.new(['127.0.0.1'], 0)
+      expect(server.closed?).to be false
+      server.close
+      expect(server.closed?).to be true
+    end
+
+    it 'does not raise error when called multiple times' do
+      server = SCTP::Server.new(['127.0.0.1'], 0)
+      server.close
+      expect { server.close }.not_to raise_error
+    end
+  end
+
+  describe '#to_s' do
+    it 'shows server info when open' do
+      server = SCTP::Server.new(['127.0.0.1'], 0)
+      str = server.to_s
+      expect(str).to include('SCTP::Server')
+      expect(str).to include('127.0.0.1')
+      expect(str).to include(server.local_port.to_s)
+      expect(str).to include('one-to-many')
+      server.close
+    end
+
+    it 'shows closed status when closed' do
+      server = SCTP::Server.new(['127.0.0.1'], 0)
+      server.close
+      str = server.to_s
+      expect(str).to eq('#<SCTP::Server:closed>')
+    end
+
+    it 'shows one-to-one mode correctly' do
+      server = SCTP::Server.new(['127.0.0.1'], 0, one_to_one: true)
+      str = server.to_s
+      expect(str).to include('one-to-one')
+      server.close
+    end
+  end
+
+  describe '#accept (one-to-one mode)' do
+    it 'raises error in one-to-many mode' do
+      server = SCTP::Server.new(['127.0.0.1'], 0, one_to_one: false)
+      expect { server.accept }.to raise_error(/accept.*only available in one-to-one mode/)
+      server.close
+    end
+
+    # Note: Testing actual accept() would require a client connection
+    # which is beyond the scope of basic unit tests
+  end
+
+  describe 'socket options' do
+    it 'accepts socket options during initialization' do
+      expect {
+        server = SCTP::Server.new(['127.0.0.1'], 0, autoclose: 30)
+        server.close
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'socket'


### PR DESCRIPTION
This adds an SCTP::Server class modeled after the TCPServer class in the Ruby stdlib.