### PR TITLE
Minor update for map_ipv4= method

### DIFF
--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -2592,10 +2592,14 @@ static VALUE rsctp_delete_shared_key(int argc, VALUE* argv, VALUE self){
  * call-seq:
  *    SCTP::Socket#map_ipv4=(bool)
  *
- * If set to true and the socket is type PF_INET6, then IPv4 addresses will be
+ * If set to true and the socket is type xF_INET6, then IPv4 addresses will be
  * mapped to V6 representation. If set to false (the default), then no mapping
- * will be done of V4 addresses and a user will receive both PF_INET6 and
- * PF_INET type addresses on the socket.
+ * will be done of V4 addresses and a user will receive both xF_INET6 and
+ * xF_INET type addresses on the socket.
+ *
+ * Note that setting this to true on a socket that is not type xF_INET6 is
+ * undefined behavior, and may raise an error on your platform. Otherwise it's
+ * a no-op.
  */
 static VALUE rsctp_map_ipv4(VALUE self, VALUE v_bool){
   int fileno, boolean;

--- a/spec/map_ipv4_spec.rb
+++ b/spec/map_ipv4_spec.rb
@@ -3,6 +3,10 @@ require_relative 'shared_spec_helper'
 RSpec.describe SCTP::Socket, type: :sctp_socket do
   include_context 'sctp_socket_helpers'
 
+  before do
+    @socket = described_class.new(Socket::AF_INET6)
+  end
+
   context "map_ipv4= and map_ipv4?" do
     example "map_ipv4= basic functionality" do
       expect(@socket).to respond_to(:map_ipv4=)


### PR DESCRIPTION
It turns out that BSD gets upset if you try to set this on an IPv4 socket, whereas Linux just ignores it.

For test purposes I've changed the specs to use an IPv6 socket, and added a comment to the source.