### PR TITLE
Use server instead of socket, update connection

### DIFF
--- a/spec/get_peer_address_params_spec.rb
+++ b/spec/get_peer_address_params_spec.rb
@@ -3,25 +3,23 @@ require_relative 'shared_spec_helper'
 RSpec.describe SCTP::Socket, type: :sctp_socket do
   include_context 'sctp_socket_helpers'
 
-  context "get_peer_address_params" do
-    before do
-      @server.bindx(:addresses => addresses, :port => port, :reuse_addr => true)
-      @server.listen
-      @socket.connectx(:addresses => addresses, :port => port, :reuse_addr => true)
-    end
+  before do
+    create_connection
+  end
 
+  context "get_peer_address_params" do
     example "get_peer_address_params basic functionality" do
-      expect(@socket).to respond_to(:get_peer_address_params)
+      expect(@server).to respond_to(:get_peer_address_params)
     end
 
     example "get_peer_address_params returns expected struct type" do
-      params = @socket.get_peer_address_params
+      params = @server.get_peer_address_params
       expect(params).to be_a(Struct)
       expect(params.class.name).to match(/PeerAddressParams/)
     end
 
     example "get_peer_address_params returns struct with expected members" do
-      params = @socket.get_peer_address_params
+      params = @server.get_peer_address_params
       expect(params).to respond_to(:association_id)
       expect(params).to respond_to(:address)
       expect(params).to respond_to(:heartbeat_interval)
@@ -32,7 +30,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
     end
 
     example "get_peer_address_params returns struct with expected value types" do
-      params = @socket.get_peer_address_params
+      params = @server.get_peer_address_params
       expect(params.association_id).to be_a(Integer)
       expect(params.address).to be_a(String)
       expect(params.heartbeat_interval).to be_a(Integer)
@@ -43,19 +41,19 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
     end
 
     example "get_peer_address_params address is a valid IP address" do
-      params = @socket.get_peer_address_params
+      params = @server.get_peer_address_params
       expect(params.address).to match(/\A\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\z/)
     end
 
     example "get_peer_address_params does not accept any arguments" do
-      expect{ @socket.get_peer_address_params(true) }.to raise_error(ArgumentError)
-      expect{ @socket.get_peer_address_params({}) }.to raise_error(ArgumentError)
-      expect{ @socket.get_peer_address_params(1, 2) }.to raise_error(ArgumentError)
+      expect{ @server.get_peer_address_params(true) }.to raise_error(ArgumentError)
+      expect{ @server.get_peer_address_params({}) }.to raise_error(ArgumentError)
+      expect{ @server.get_peer_address_params(1, 2) }.to raise_error(ArgumentError)
     end
 
     example "get_peer_address_params returns consistent values on multiple calls" do
-      params1 = @socket.get_peer_address_params
-      params2 = @socket.get_peer_address_params
+      params1 = @server.get_peer_address_params
+      params2 = @server.get_peer_address_params
       expect(params1.association_id).to eq(params2.association_id)
       expect(params1.address).to eq(params2.address)
       expect(params1.flags).to eq(params2.flags)


### PR DESCRIPTION
This method is, I think, really only meant for server side sockets. BSD will blow up because it doesn't like the association id on client side.

While I was here I refactored it to use the helper connection.