### PR TITLE
Fix auth methods

### DIFF
--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -2584,8 +2584,8 @@ static VALUE rsctp_delete_shared_key(int argc, VALUE* argv, VALUE self){
 
   size = sizeof(struct sctp_authkeyid);
 
-  if(sctp_opt_info(fileno, assoc_id, SCTP_AUTH_DELETE_KEY, (void*)&authkey, &size) < 0)
-    rb_raise(rb_eSystemCallError, "sctp_opt_info: %s", strerror(errno));
+  if(setsockopt(fileno, IPPROTO_SCTP, SCTP_AUTH_DELETE_KEY, (void*)&authkey, size) < 0)
+    rb_raise(rb_eSystemCallError, "setsockopt: %s", strerror(errno));
 
   return INT2NUM(authkey.scact_keynumber);
 }

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -2323,8 +2323,8 @@ static VALUE rsctp_enable_auth_support(int argc, VALUE* argv, VALUE self){
   assoc_value.assoc_id = assoc_id;
   assoc_value.assoc_value = 1;
 
-  if(sctp_opt_info(fileno, assoc_id, SCTP_AUTH_SUPPORTED, (void*)&assoc_value, &size) < 0)
-    rb_raise(rb_eSystemCallError, "sctp_opt_info: %s", strerror(errno));
+  if(setsockopt(fileno, IPPROTO_SCTP, SCTP_AUTH_SUPPORTED, (void*)&assoc_value, size) < 0)
+    rb_raise(rb_eSystemCallError, "setsockopt: %s", strerror(errno));
 
   return self;
 }
@@ -2368,7 +2368,7 @@ static VALUE rsctp_get_auth_support(int argc, VALUE* argv, VALUE self){
 
 /*
  * call-seq:
- *    SCTP::Socket#set_shared_key(key, keynum, association_id=nil)
+ *    SCTP::Socket#set_shared_key(key, keynum=1, association_id=nil)
  *
  *  This option will set a shared secret key which is used to build an
  *  association shared key.

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -2432,8 +2432,8 @@ static VALUE rsctp_set_shared_key(int argc, VALUE* argv, VALUE self){
   auth_key->sca_keylength = strlen(key);
   memcpy(auth_key->sca_key, byte_array, sizeof(byte_array));
 
-  if(sctp_opt_info(fileno, assoc_id, SCTP_AUTH_KEY, (void*)auth_key, &size) < 0)
-    rb_raise(rb_eSystemCallError, "sctp_opt_info: %s", strerror(errno));
+  if(setsockopt(fileno, IPPROTO_SCTP, SCTP_AUTH_KEY, (void*)auth_key, size) < 0)
+    rb_raise(rb_eSystemCallError, "setsockopt: %s", strerror(errno));
 
   return self;
 }
@@ -2528,8 +2528,8 @@ static VALUE rsctp_set_active_shared_key(int argc, VALUE* argv, VALUE self){
   authkey.scact_keynumber = (uint)keynum;
   size = sizeof(struct sctp_authkeyid);
 
-  if(sctp_opt_info(fileno, assoc_id, SCTP_AUTH_ACTIVE_KEY, (void*)&authkey, &size) < 0)
-    rb_raise(rb_eSystemCallError, "sctp_opt_info: %s", strerror(errno));
+  if(setsockopt(fileno, IPPROTO_SCTP, SCTP_AUTH_ACTIVE_KEY, (void*)&authkey, size) < 0)
+    rb_raise(rb_eSystemCallError, "setsockopt: %s", strerror(errno));
 
   return self;
 }

--- a/spec/shared_key_spec.rb
+++ b/spec/shared_key_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result).to eq(@socket)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -35,14 +35,19 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result).to be_a(Integer)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
     example "set_shared_key requires key and keynum arguments" do
       expect { @socket.set_shared_key }.to raise_error(ArgumentError)
-      # keynum is optional and defaults to 1, so this should work
-      expect { @socket.set_shared_key("key") }.not_to raise_error
+      # keynum is optional and defaults to 1, so this should work if auth is supported
+      begin
+        @socket.set_shared_key("key")
+      rescue SystemCallError => e
+        # Expected if SCTP authentication is not supported/configured
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
+      end
     end
 
     example "delete_shared_key requires keynum argument" do
@@ -64,7 +69,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result).to eq(@socket)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -83,7 +88,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result).to be_a(Integer)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -95,7 +100,12 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
     example "set_shared_key validates keynum parameter type" do
       expect { @socket.set_shared_key("key", "invalid") }.to raise_error(TypeError)
       # nil is valid as keynum defaults to 1
-      expect { @socket.set_shared_key("key", nil) }.not_to raise_error
+      begin
+        @socket.set_shared_key("key", nil)
+      rescue SystemCallError => e
+        # Expected if SCTP authentication is not supported/configured
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
+      end
     end
 
     example "delete_shared_key validates keynum parameter type" do
@@ -135,7 +145,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result).to eq(@socket)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -148,7 +158,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         end
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -158,7 +168,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result).to eq(@socket)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -168,7 +178,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result).to be_a(Integer)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -178,7 +188,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result).to equal(@socket)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -189,7 +199,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result).to eq(5)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -213,7 +223,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(association_id).to be >= 0
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -236,7 +246,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result4).to be_a(Integer)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -250,7 +260,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(result).to eq(30)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -269,7 +279,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         @socket.delete_shared_key(40)
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -290,7 +300,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         unconnected_socket.close
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
@@ -308,7 +318,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
         expect(association_id).to be > 0 # Connected socket should have non-zero association
       rescue SystemCallError => e
         # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/sctp_opt_info|not supported|Invalid argument|Permission denied/)
+        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
         # But we should still have a valid association ID
         association_id = @socket.association_id
         expect(association_id).to be >= 0


### PR DESCRIPTION
Several auth related methods were busted and should've been using setsockopt. The `set_shared_key` method was also broken for other reasons.

Specs were updated to handle the changes.