### PR TITLE
Refactor shared key specs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,6 +28,7 @@ jobs:
           sudo ip addr add 1.1.1.2/24 dev dummy2
           sudo ip link set dummy1 up
           sudo ip link set dummy2 up
+          sudo sysctl -w net.sctp.auth_enable=1
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,9 +19,10 @@ jobs:
         ruby-version: ['3.2', '3.3', '3.4']
     steps:
     - uses: actions/checkout@v4
-    - name: Install SCTP headers
+    - name: Setup SCTP
       run: |
           sudo apt-get install libsctp-dev lksctp-tools
+          sudo modprobe sctp
           sudo ip link add dummy1 type dummy
           sudo ip link add dummy2 type dummy
           sudo ip addr add 1.1.1.1/24 dev dummy1

--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -2404,6 +2404,8 @@ static VALUE rsctp_set_shared_key(int argc, VALUE* argv, VALUE self){
 
   rb_scan_args(argc, argv, "12", &v_key, &v_keynumber, &v_assoc_id);
 
+  CHECK_SOCKET_CLOSED(self);
+
   fileno = NUM2INT(rb_iv_get(self, "@fileno"));
   key = StringValuePtr(v_key);
   len = RSTRING_LEN(v_key); // Use Ruby's string length, not strlen
@@ -2570,6 +2572,8 @@ static VALUE rsctp_delete_shared_key(int argc, VALUE* argv, VALUE self){
   uint keynum;
 
   rb_scan_args(argc, argv, "11", &v_keynum, &v_assoc_id);
+
+  CHECK_SOCKET_CLOSED(self);
 
   bzero(&authkey, sizeof(authkey));
 

--- a/spec/shared_key_spec.rb
+++ b/spec/shared_key_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
   context "set_shared_key" do
     before do
       create_connection
+      @socket.enable_auth_support(@server.association_id)
     end
 
     example "set_shared_key basic functionality" do

--- a/spec/shared_key_spec.rb
+++ b/spec/shared_key_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
   context "set_shared_key" do
     before do
       create_connection
-      @socket.enable_auth_support(@server.association_id)
     end
 
     example "set_shared_key basic functionality" do
@@ -44,6 +43,50 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
     example "set_shared_key rejects too many arguments" do
       expect { @socket.set_shared_key("key", 1, 0, "extra") }.to raise_error(ArgumentError)
     end
+
+    example "set_shared_key with different key values" do
+      # Test with regular string key
+      result = @socket.set_shared_key("regularkey", 1)
+      expect(result).to eq(@socket)
+
+      # Test with empty string (null key)
+      result = @socket.set_shared_key("", 2)
+      expect(result).to eq(@socket)
+
+      # Test with binary data
+      result = @socket.set_shared_key("\x00\x01\x02\x03", 3)
+      expect(result).to eq(@socket)
+
+      # Test with longer key
+      result = @socket.set_shared_key("a" * 100, 4)
+      expect(result).to eq(@socket)
+    end
+
+    example "set_shared_key with special key number 0 (null key)" do
+      result = @socket.set_shared_key("", 0)
+      expect(result).to eq(@socket)
+    end
+
+    example "set_shared_key handles closed socket gracefully" do
+      @socket.close
+      expect { @socket.set_shared_key("key", 1) }.to raise_error(IOError, "socket is closed")
+    end
+
+    example "set_shared_key uses socket's association_id when nil passed" do
+      result = @socket.set_shared_key("testkey", 10, nil)
+      expect(result).to eq(@socket)
+    end
+
+    example "set_shared_key on an unconnected socket" do
+      unconnected_socket = described_class.new
+      unconnected_result = unconnected_socket.set_shared_key("unconnectedkey", 51)
+      expect(unconnected_result).to eq(unconnected_socket)
+    end
+
+    example "set_shared_key is compatible with auth support workflow" do
+      @socket.enable_auth_support(@server.association_id)
+      expect{ @socket.set_shared_key("authkey", 40) }.not_to raise_error
+    end
   end
 
   context "delete_shared_key" do
@@ -53,7 +96,7 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
 
     example "delete_shared_key basic functionality" do
       result = @socket.delete_shared_key(1)
-      expect(result).to be_a(Integer)
+      expect(result).to eq(1)
     end
 
     example "delete_shared_key requires keynum argument" do
@@ -82,205 +125,37 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
     example "delete_shared_key rejects too many arguments" do
       expect { @socket.delete_shared_key(1, 0, "extra") }.to raise_error(ArgumentError)
     end
-  end
-=begin
-    example "set_shared_key with different key values" do
-      begin
-        # Test with regular string key
-        result = @socket.set_shared_key("regularkey", 1)
-        expect(result).to eq(@socket)
 
-        # Test with empty string (null key)
-        result = @socket.set_shared_key("", 2)
-        expect(result).to eq(@socket)
-
-        # Test with binary data
-        result = @socket.set_shared_key("\x00\x01\x02\x03", 3)
-        expect(result).to eq(@socket)
-
-        # Test with longer key
-        result = @socket.set_shared_key("a" * 100, 4)
-        expect(result).to eq(@socket)
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-      end
-    end
-
-    example "delete_shared_key with different keynum values" do
-      begin
-        # Test with various key numbers
-        [1, 2, 10, 100].each do |keynum|
-          result = @socket.delete_shared_key(keynum)
-          expect(result).to be_a(Integer)
-        end
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-      end
-    end
-
-    example "set_shared_key with special key number 0 (null key)" do
-      begin
-        result = @socket.set_shared_key("", 0)
-        expect(result).to eq(@socket)
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-      end
-    end
-
-    example "delete_shared_key with special key number 0 (disables null key)" do
-      begin
-        result = @socket.delete_shared_key(0)
+    # TODO: Verify behavior
+    example "delete_shared_key with different keynum values", :linux do
+      [1, 2, 10, 100].each do |keynum|
+        result = @socket.delete_shared_key(keynum)
         expect(result).to be_a(Integer)
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
       end
     end
 
-    example "set_shared_key returns self" do
-      begin
-        result = @socket.set_shared_key("testkey", 5)
-        expect(result).to equal(@socket)
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-      end
+    # TODO: Verify behavior
+    example "delete_shared_key with special key number 0 (disables null key)", :linux do
+      result = @socket.delete_shared_key(0)
+      expect(result).to be_a(Integer)
     end
 
-    example "delete_shared_key returns integer key number" do
-      begin
-        result = @socket.delete_shared_key(5)
-        expect(result).to be_a(Integer)
-        expect(result).to eq(5)
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-      end
-    end
-
-    example "methods handle closed socket gracefully" do
+    example "delete_shared_key handles closed socket gracefully" do
       @socket.close
-      expect { @socket.set_shared_key("key", 1) }.to raise_error(TypeError, /no implicit conversion from nil to integer/)
-      expect { @socket.delete_shared_key(1) }.to raise_error(TypeError, /no implicit conversion from nil to integer/)
+      expect { @socket.delete_shared_key(1) }.to raise_error(IOError, "socket is closed")
     end
 
-    example "methods use socket's association_id when nil passed" do
-      begin
-        association_id = @socket.association_id
-
-        # Both methods should work with nil association_id
-        result1 = @socket.set_shared_key("testkey", 10, nil)
-        expect(result1).to eq(@socket)
-
-        result2 = @socket.delete_shared_key(10, nil)
-        expect(result2).to be_a(Integer)
-
-        expect(association_id).to be >= 0
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-      end
+    example "delete_shared_key uses socket's association_id when nil passed" do
+      @socket.set_shared_key("testkey", 10, nil)
+      result = @socket.delete_shared_key(10, nil)
+      expect(result).to eq(10)
     end
 
-    example "methods work with different association_id values" do
-      begin
-        association_id = @socket.association_id
-
-        # Test with explicit association_id
-        result1 = @socket.set_shared_key("testkey", 20, association_id)
-        expect(result1).to eq(@socket)
-
-        result2 = @socket.delete_shared_key(20, association_id)
-        expect(result2).to be_a(Integer)
-
-        # Test with 0 (endpoint level)
-        result3 = @socket.set_shared_key("endpointkey", 21, 0)
-        expect(result3).to eq(@socket)
-
-        result4 = @socket.delete_shared_key(21, 0)
-        expect(result4).to be_a(Integer)
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-      end
+    example "delete_shared_key on an unconnected socket" do
+      unconnected_socket = described_class.new
+      unconnected_socket.set_shared_key("unconnectedkey", 51)
+      unconnected_result = unconnected_socket.delete_shared_key(51)
+      expect(unconnected_result).to eq(51)
     end
-
-    example "set_shared_key and delete_shared_key work together" do
-      begin
-        # Set a key
-        @socket.set_shared_key("workflowkey", 30)
-
-        # Delete the same key
-        result = @socket.delete_shared_key(30)
-        expect(result).to eq(30)
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-      end
-    end
-
-    example "methods are compatible with auth support workflow" do
-      begin
-        # Enable auth support first
-        @socket.enable_auth_support
-
-        # Set a shared key
-        @socket.set_shared_key("authkey", 40)
-
-        # Try to set it as active (might fail if key management not fully supported)
-        @socket.set_active_shared_key(40)
-
-        # Clean up
-        @socket.delete_shared_key(40)
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-      end
-    end
-
-    example "methods work on connected socket vs unconnected socket" do
-      begin
-        # Test on connected socket (our @socket)
-        connected_result = @socket.set_shared_key("connectedkey", 50)
-        expect(connected_result).to eq(@socket)
-
-        # Test on unconnected socket
-        unconnected_socket = described_class.new
-        unconnected_result = unconnected_socket.set_shared_key("unconnectedkey", 51)
-        expect(unconnected_result).to eq(unconnected_socket)
-
-        # Clean up
-        @socket.delete_shared_key(50)
-        unconnected_socket.delete_shared_key(51)
-        unconnected_socket.close
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-      end
-    end
-
-    example "methods utilize established SCTP association" do
-      begin
-        # Test that methods work with the actual established association
-        association_id = @socket.association_id
-
-        # Set key using the real association ID from connected socket
-        @socket.set_shared_key("associationkey", 60, association_id)
-
-        # Delete key using the real association ID
-        result = @socket.delete_shared_key(60, association_id)
-        expect(result).to eq(60)
-        expect(association_id).to be > 0 # Connected socket should have non-zero association
-      rescue SystemCallError => e
-        # Expected if SCTP authentication is not supported/configured
-        expect(e.message).to match(/setsockopt|not supported|Invalid argument|Permission denied/)
-        # But we should still have a valid association ID
-        association_id = @socket.association_id
-        expect(association_id).to be >= 0
-      end
-    end
-=end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,5 @@ require_relative 'shared_spec_helper'
 RSpec.configure do |config|
   config.include_context "sctp_socket_helpers", type: :sctp_socket
   config.filter_run_excluding(:bsd) unless RbConfig::CONFIG['host_os'] =~ /bsd|dragonfly/
+  config.filter_run_excluding(:linux) unless RbConfig::CONFIG['host_os'] =~ /linux/
 end


### PR DESCRIPTION
Refactored on the assumption that auth is actually enabled on your system. I'll make a separate PR that actually checks that.

I also added some checks for a closed socket in the source.

I also had to modify the github action slightly for this to work.