### PR TITLE
Check for closed socket in sendv, update spec

### DIFF
--- a/ext/sctp/socket.c
+++ b/ext/sctp/socket.c
@@ -851,6 +851,8 @@ static VALUE rsctp_sendv(VALUE self, VALUE v_options){
 
   Check_Type(v_message, T_ARRAY);
 
+  CHECK_SOCKET_CLOSED(self);
+
   if(!NIL_P(v_addresses)){
     Check_Type(v_addresses, T_ARRAY);
     num_ip = (int)RARRAY_LEN(v_addresses);

--- a/spec/sendv_spec.rb
+++ b/spec/sendv_spec.rb
@@ -54,10 +54,10 @@ RSpec.describe SCTP::Socket, type: :sctp_socket do
       expect(@socket.sendv(options)).to eq(options[:message].first.length)
     end
 
-    example "sendv with connection emCallError" do
+    example "sendv without connection raises an error" do
       @server.close(linger: 0) if @server rescue nil
       options = { message: ["Hello", "World"] }
-      expect{ @socket.sendv(options) }.to raise_error(SystemCallError)
+      expect{ @server.sendv(options) }.to raise_error(IOError, "socket is closed")
     end
 
     example "sendv accepts multiple message parts" do


### PR DESCRIPTION
This was failing locally, so I added a more explicit check for a closed socket in sendv and updated the spec.